### PR TITLE
Product update form

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -87,17 +87,17 @@ class ProductController extends Controller
                 'consignment', 'sales'
             ])
             ->get();
-            dd('remote inventory update');
+            // dd('remote inventory update');
         }
         elseif ($inventory === 'internal') {
             $inventoryStatuses = InventoryStatus::where('name', 'on hands')
                 ->firstOrFail();
-            return View('inventory/inventory-update', compact('inventory', 'inventoryStatuses'));
         }
         else {
             return redirect()->back()
                 ->withErrors('Please choose an existing inventory.');
         }
+        return View('inventory/inventory-update', compact('inventory', 'inventoryStatuses'));
     }
 
     /**

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -83,11 +83,15 @@ class ProductController extends Controller
     public function edit($inventory)
     {
         if ($inventory === 'remote') {
-            $inventoryStatuses = InventoryStatus::findOrFail([2, 3]);
+            $inventoryStatuses = InventoryStatus::whereIn('name', [
+                'consignment', 'sales'
+            ])
+            ->get();
             dd('remote inventory update');
         }
         elseif ($inventory === 'internal') {
-            $inventoryStatuses = InventoryStatus::findOrFail(1);
+            $inventoryStatuses = InventoryStatus::where('name', 'on hands')
+                ->firstOrFail();
             return View('inventory/inventory-update', compact('inventory', 'inventoryStatuses'));
         }
         else {
@@ -114,12 +118,14 @@ class ProductController extends Controller
             ]);
             $lens = Product::where('sn', '=', $request->serial_number)
                 ->where('exclude', '=', 0)
-                ->first();
+                ->firstOrFail();
             if ($lens == null) {
                 return redirect()->back()
                     ->withErrors('The specified lens does not exist or is excluded.');
             }
-            $request->inventory_status = 1;
+            $inventoryStatus = InventoryStatus::where('name', 'on hands')
+                ->firstOrFail();
+            $request->inventory_status = $inventoryStatus->id;
         }
         elseif ($inventory === 'remote') {
             dd('remote inventory update');

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -80,9 +80,20 @@ class ProductController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function edit()
+    public function edit($inventory)
     {
-        return View('inventory/inventory-update', compact('statuses'));
+        if ($inventory === 'remote') {
+            $inventoryStatuses = InventoryStatus::findOrFail([2, 3]);
+            dd('remote inventory update');
+        }
+        elseif ($inventory === 'internal') {
+            $inventoryStatuses = InventoryStatus::findOrFail(1);
+            return View('inventory/inventory-update', compact('inventory', 'inventoryStatuses'));
+        }
+        else {
+            return redirect()->back()
+                ->withErrors('Please choose an existing inventory.');
+        }
     }
 
     /**
@@ -91,30 +102,39 @@ class ProductController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request)
+    public function update(Request $request, $inventory)
     {
-        $this->validate($request, [
-            'inventory_status' => 'required|in:1,4|exists:inventory_status,id',
-            'serial_number' => [
-                'required',
-                'regex:/F[0-9]{8}/',
-                'exists:lense,sn',
-            ],
-        ]);
-
-        $lens = Product::where('sn', '=', $request->serial_number)
-            ->where('exclude', '=', 0)
-            ->first();
-        if ($lens == null) {
-            return redirect()->back()
-                ->withErrors('The specified lens does not exist or is excluded');
+        if ($inventory === 'internal') {
+            $this->validate($request, [
+                'serial_number' => [
+                    'required',
+                    'regex:/F[0-9]{8}/',
+                    'exists:lense,sn',
+                ],
+            ]);
+            $lens = Product::where('sn', '=', $request->serial_number)
+                ->where('exclude', '=', 0)
+                ->first();
+            if ($lens == null) {
+                return redirect()->back()
+                    ->withErrors('The specified lens does not exist or is excluded.');
+            }
+            $request->inventory_status = 1;
         }
+        elseif ($inventory === 'remote') {
+            dd('remote inventory update');
+        }
+        else {
+            return redirect()->back()
+                ->withErrors('Please choose an existing inventory.');
+        }
+
         $lens->update([
             'status' => $request->inventory_status,
         ]);
 
         return redirect()->back()
-            ->with('status', 'Lens successfully updated');
+            ->with('status', 'Lens\' status successfully updated');
     }
 
     /**

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -84,18 +84,17 @@ class ProductController extends Controller
     {
         if ($inventory === 'remote') {
             $inventoryStatuses = InventoryStatus::whereIn('name', [
-                'consignment', 'sales'
+                'consignment', 'sales',
             ])
             ->get();
-        }
-        elseif ($inventory === 'internal') {
+        } elseif ($inventory === 'internal') {
             $inventoryStatuses = InventoryStatus::where('name', 'on hands')
                 ->firstOrFail();
-        }
-        else {
+        } else {
             return redirect()->back()
                 ->withErrors('Please choose an existing inventory.');
         }
+
         return View('inventory/inventory-update', compact('inventory', 'inventoryStatuses'));
     }
 
@@ -118,13 +117,12 @@ class ProductController extends Controller
             $inventoryStatus = InventoryStatus::where('name', 'on hands')
                 ->firstOrFail();
             $request->inventory_status = $inventoryStatus->id;
-        }
-        elseif ($inventory === 'remote') {
-            $func = function($status) {
+        } elseif ($inventory === 'remote') {
+            $func = function ($status) {
                 return $status['id'];
             };
             $inventoryStatuses = InventoryStatus::whereIn('name', [
-                'consignment', 'sales'
+                'consignment', 'sales',
             ])
             ->get();
             $legalStatuses = implode(',', array_map($func, $inventoryStatuses->toArray()));
@@ -132,7 +130,7 @@ class ProductController extends Controller
                 'inventory_status' => [
                     'required',
                     'exists:inventory_status,id',
-                    'in:' . $legalStatuses
+                    'in:'.$legalStatuses,
                 ],
                 'serial_number' => [
                     'required',
@@ -140,8 +138,7 @@ class ProductController extends Controller
                     'exists:lense,sn',
                 ],
             ]);
-        }
-        else {
+        } else {
             return redirect()->back()
                 ->withErrors('Please choose an existing inventory.');
         }

--- a/resources/views/base.twig
+++ b/resources/views/base.twig
@@ -12,6 +12,7 @@
         {% endif %}
         {% if errors.all %}
             <p class="alert alert-danger">
+                <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
                 {% for error in errors.all %}
                     {{ error }}
                 {% endfor %}
@@ -19,6 +20,7 @@
         {% endif %}
         {% if session('status') %}
             <p class="alert alert-success">
+                <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
                 {{ session('status') }}
             </p>
         {% endif %}

--- a/resources/views/inventory/inventory-update.twig
+++ b/resources/views/inventory/inventory-update.twig
@@ -16,7 +16,16 @@
             </div>
         </div>
         {% if inventory == 'remote' and inventoryStatuses is defined %}
-            Remote inventory update
+            {% for status in inventoryStatuses %}
+                <div class="radio">
+                        <label>
+                            <input type="radio" name="inventory_status"
+                                value="{{ status.id }}"
+                            >
+                            {{ status.name | capitalize }}
+                        </label>
+                </div>
+            {% endfor %}
         {% endif %}
         <button class="btn btn-primary" type="submit" name="submit">Insert</button>
     </form>

--- a/resources/views/inventory/inventory-update.twig
+++ b/resources/views/inventory/inventory-update.twig
@@ -1,6 +1,6 @@
 {% extends 'base.twig' %}
 {% block body %}
-    <h1>On hands inventory entry or return</h1>
+    <h1>{{ inventory == 'remote' ? 'Remote inventory entry' : "On hands inventory entry or return" }}</h1>
     <p class="lead">
         Insert a valid serial number to put the concerned lense into
         the on hands inventory.

--- a/resources/views/inventory/inventory-update.twig
+++ b/resources/views/inventory/inventory-update.twig
@@ -5,7 +5,7 @@
         Insert a valid serial number to put the concerned lense into
         the on hands inventory.
     </p>
-    <form action="{{ route('product.update')}}" method="post">
+    <form action="{{ route('product.update', {inventory: inventory}) }}" method="post">
         {{ csrf_field() }}
         <input name="_method" type="hidden" value="put">
         <div class="form-group row">
@@ -15,7 +15,9 @@
                     name="serial_number" placeholder="F12345678" pattern="F[0-9]{8}" required>
             </div>
         </div>
-        <input class="form-check-input" type="radio" name="inventory_status" value="1" hidden>
+        {% if inventory == 'remote' and inventoryStatuses is defined %}
+            Remote inventory update
+        {% endif %}
         <button class="btn btn-primary" type="submit" name="submit">Insert</button>
     </form>
 {% endblock %}

--- a/resources/views/navigation-bar.twig
+++ b/resources/views/navigation-bar.twig
@@ -9,7 +9,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <!-- <a class="navbar-brand" href="#">Project name</a> -->
+                {# <a class="navbar-brand" href="#">Project name</a> #}
             </div>
             <div id="navbar" class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
@@ -19,11 +19,11 @@
                             Inventory <span class="caret"></span>
                         </a>
                         <ul class="dropdown-menu">
-                            <li><a href="{{ route('product.edit') }}">Move to Packship</a></li>
                             <li><a href="{{ route('product.index', {inventorySlug: 'on-hands'}) }}">On Hands Inventory</a></li>
                             <li><a href="{{ route('product.index', {inventorySlug: 'consignment'}) }}">Consignment Inventory</a></li>
-                            <!-- <li><a href="">Update a product's status</a></li> -->
                             <li><a href="{{ route('product.index', {inventorySlug: 'sales'}) }}">Sales</a></li>
+                            <li><a href="{{ route('product.edit', {inventory: 'internal'}) }}">Move to Packship</a></li>
+                            <li><a href="{{ route('product.edit', {inventory: 'remote'}) }}">Update a product's status</a></li>
                         </ul>
                     </li>
                 </ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,5 +22,5 @@ Route::post('logout', 'Auth\LoginController@logout')->name('logout');
 Route::get('/home', 'HomeController@index')->name('home');
 
 Route::get('product/{inventorySlug}', 'ProductController@index')->name('product.index');
-Route::get('inventory/update', 'ProductController@edit')->name('product.edit');
-Route::put('inventory/update', 'ProductController@update')->name('product.update');
+Route::get('inventory/{inventory}/update', 'ProductController@edit')->name('product.edit');
+Route::put('inventory/{inventory}/update', 'ProductController@update')->name('product.update');


### PR DESCRIPTION
This form can be used to update a product status.
It could be one page with a third radio button for the `on hands` inventory but I splitted it in two pages. I did so because user should not be supposed to put a product in both `sales` and `consignment` inventories through this form. User should use an other form (`orders form`) which is not yet implemented. This form will *not* be implemented now because it is not in the priority goals. I also splitted it in two pages because this kind of action are a little bit critical and user should always know in which inventory he is working.
